### PR TITLE
Amend value of the ensure attribute for the telegraf.conf file resource

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,7 +9,7 @@
 class telegraf::config {
 
   file { '/etc/opt/telegraf/telegraf.conf':
-    ensure  => $telegraf::ensure,
+    ensure  => file,
     content => template('telegraf/telegraf.conf.erb'),
     mode    => '0640',
     owner   => 'root',


### PR DESCRIPTION
This fixes a Puppet parser value, as the value inherited from the telegraf class - `'installed'` - isn't valid for the file type.

Fixes #1.