### PR TITLE
Refactor and address dependancy issues when installing on Debian / Ubuntu

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,3 +1,4 @@
 forge 'https://forgeapi.puppetlabs.com'
 
 mod 'puppetlabs/inifile', '>= 1.0.0'
+mod 'maestrodev/wget', '>= 1.6.0'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -1,8 +1,10 @@
 FORGE
   remote: https://forgeapi.puppetlabs.com
   specs:
+    maestrodev-wget (1.7.1)
     puppetlabs-inifile (1.2.0)
 
 DEPENDENCIES
+  maestrodev-wget (>= 1.6.0)
   puppetlabs-inifile (>= 1.0.0)
 

--- a/metadata.json
+++ b/metadata.json
@@ -18,6 +18,10 @@
     {
       "name": "puppetlabs/inifile",
       "version_requirement": ">= 1.0.0"
+    },
+    {
+      "name": "maestrodev/wget",
+      "version_requirement": ">= 1.6.0 <2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Fixes #3 and simplifies things.  Note that I've proposed usage of the (relatively) standard `wget` module in order to tidy this manifest up a little.

It also fixes a minor `puppet-lint` error regarding a string containing only a variable on line 23.