### PR TITLE
Parameterization + elasticsearch plugin

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,7 +10,7 @@ class telegraf::config {
 
   file { $telegraf::config_base_file:
     ensure  => file,
-    content => template('telegraf/telegraf.conf.erb'),
+    content => template($::telegraf::config_template),
     mode    => '0644',
     owner   => 'root',
     group   => 'telegraf',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,25 +41,36 @@
 #  Configures agent hostname for sending it to the sinks
 #
 class telegraf (
-  $ensure                    = 'installed',
-  $version                   = '0.2.0',
-  $install_from_repository   = true,
-  $config_base_file          = '/etc/opt/telegraf/telegraf.conf',
-  $config_directory          = '/etc/opt/telegraf/telegraf.d',
+  $ensure                     = $telegraf::params::ensure,
+  $version                    = $telegraf::params::version,
+  $install_from_repository    = $telegraf::params::install_from_repository,
+  $config_template            = $telegraf::params::config_template,
+  $config_base_file           = $telegraf::params::config_base_file,
+  $config_directory           = $telegraf::params::config_directory,
 
   # [outputs.influxdb] section of telegraf.conf
-  $outputs_influxdb_enabled  = true,
-  $outputs_influxdb_urls     = ['http://localhost:8086'],
-  $outputs_influxdb_database = 'telegraf',
-  $outputs_influxdb_username = 'telegraf',
-  $outputs_influxdb_password = 'metricsmetricsmetricsmetrics',
+  $outputs_influxdb_enabled   = $telegraf::params::outputs_influxdb_enabled,
+  $outputs_influxdb_urls      = $telegraf::params::outputs_influxdb_urls,
+  $outputs_influxdb_database  = $telegraf::params::outputs_influxdb_database,
+  $outputs_influxdb_username  = $telegraf::params::outputs_influxdb_username,
+  $outputs_influxdb_password  = $telegraf::params::outputs_influxdb_password,
 
   # [tags] section of telegraf.conf
-  $tags                      = undef,
+  $tags                       = $telegraf::params::tags,
 
   # [agent]
-  $agent_hostname            = 'localhost',
-)
+  $agent_hostname             = $telegraf::params::agent_hostname,
+  $agent_interval             = $telegraf::params::agent_interval,
+
+  # [[plugins.cpu]]
+  $cpu_percpu                 = $telegraf::params::cpu_percpu,
+  $cpu_totalcpu                = $telegraf::params::cpu_totalcpu,
+  $cpu_drop                   = $telegraf::params::cpu_drop,
+  
+  # [[plugins.disk]]
+  $disk_mountpoints           = $telegraf::params::mountpoints
+
+) inherits telegraf::params
 {
   class { 'telegraf::install': }
   ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,33 @@
+class telegraf::params {
+
+  $ensure                    = 'installed'
+  $version                   = '0.2.4'
+  $install_from_repository   = true
+  $config_template           = 'telegraf/telegraf.conf.erb'
+  $config_base_file          = '/etc/opt/telegraf/telegraf.conf'
+  $config_directory          = '/etc/opt/telegraf/telegraf.d'
+
+  # [outputs.influxdb] section of telegraf.conf
+  $outputs_influxdb_enabled  = true
+  $outputs_influxdb_urls     = ['http://localhost:8086']
+  $outputs_influxdb_database = 'telegraf'
+  $outputs_influxdb_username = 'telegraf'
+  $outputs_influxdb_password = 'metricsmetricsmetricsmetrics'
+
+  # [tags] section of telegraf.conf
+  $tags                      = undef
+
+  # [agent]
+  $agent_hostname            = 'localhost'
+  $agent_interval            = '10s'
+
+  # [[plugins.cpu]]
+  $cpu_percpu                 = true
+  $cpu_totalcpu                = true
+  $cpu_drop                   = ["cpu_time"]
+
+  # [[plugins.disk]]
+  # The default value for this is NO value.
+  #$disk_mountpoints
+
+}

--- a/manifests/plugins/elasticsearch.pp
+++ b/manifests/plugins/elasticsearch.pp
@@ -1,0 +1,35 @@
+# == Class: telegraf::plugins::elasticsearch
+#
+# this plugin adds the elasticsearch plugin to telegraf
+#
+# === Parameters
+#
+#
+# === Examples
+#
+#  include telegraf::plugins::elasticsearch
+#
+# === Authors
+#
+# Roman Plessl <roman.plessl@nine.ch>
+#
+# === Copyright
+#
+# Copyright 2015 Roman Plessl, Nine Internet Solutions AG
+#
+class telegraf::plugins::elasticsearch (
+  $servers          = ["http://localhost:9200"],
+  $cluster_health   = true,
+  $local            = true,
+){
+
+  file { "${telegraf::config_directory}/41-elasticsearch.conf":
+    ensure  => file,
+    content => template('telegraf/plugins/41-elasticsearch.conf.erb'),
+    mode    => '0644',
+    owner   => 'root',
+    group   => 'telegraf',
+    notify  => Service['telegraf'];
+  }
+
+}

--- a/templates/plugins/41-elasticsearch.conf.erb
+++ b/templates/plugins/41-elasticsearch.conf.erb
@@ -1,0 +1,12 @@
+# THIS FILE IS MANAGED BY PUPPET (created by telegraf::plugins::elasticsearch)
+
+###############################################################################
+#                              PLUGIN ELASTICSEARCH                           #
+###############################################################################
+
+
+# Read metrics from elasticsearch
+[elasticsearch]
+  servers = <%= scope['telegraf::plugins::elasticsearch::servers'].inspect %>
+  local = <%= scope['telegraf::plugins::elasticsearch::local'] %>
+  cluster_health = <%= scope['telegraf::plugins::elasticsearch::cluster_health'] %>

--- a/templates/telegraf.conf.erb
+++ b/templates/telegraf.conf.erb
@@ -26,7 +26,7 @@
 #   dc = "us-east-1"
 <% if @tags -%>
 [tags]
-<%   @tags.each do |key, value| -%>
+<%   @tags.sort.each do |key, value| -%>
    <%= key %> = "<%= value %>"
 <%   end -%>
 <% end -%>
@@ -69,7 +69,7 @@
   # Multiple urls can be specified for InfluxDB cluster support. Server to
   # write to will be randomly chosen each interval.
   # urls = ["http://localhost:8086"] # required.
-  urls = <%= @outputs_influxdb_urls %>
+  urls = <%= @outputs_influxdb_urls.inspect %>
 
   # The target database for metrics. This database must already exist
   # database = "telegraf" # required.
@@ -101,11 +101,11 @@
 # Read metrics about cpu usage
 [cpu]
   # Whether to report per-cpu stats or not
-  percpu = true
+  percpu = <%= scope['::telegraf::cpu_percpu']%>
   # Whether to report total system cpu stats or not
-  totalcpu = true
+  totalcpu = <%= scope['::telegraf::cpu_totalcpu']%>
   # Comment this line if you want the raw CPU time metrics
-  drop = ["cpu_time"]
+  drop = "<%= scope['::telegraf::cpu_drop']%>"
 
 # Read metrics about disk usage by mount point
 [disk]
@@ -113,7 +113,9 @@
   #
   # By default, telegraf gather stats for all mountpoints.
   # Setting mountpoints will restrict the stats to the specified mountpoints.
-  # Mountpoints=["/"]
+<% if scope['::telegraf::disk_mountpoints.any?']%>
+  Mountpoints = <%= scope['::telegraf::disk_mountpoints'].inspect %>
+<% end %>
 
 # Read metrics about disk IO by device
 [io]


### PR DESCRIPTION
I noticed the module wasn't following standards (params.pp for defaults) so I moved the parameters there.  I also added a config_template option for if people want to use their own template file.  Then I added a config section for the elasticsearch module.