### PR TITLE
agent_interval and agent_flush_interval

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,9 @@
 # [*agent_hostname*]
 #  Configures agent hostname for sending it to the sinks
 #
+# [*agent_flush_interval*]
+#  Configures agent flushing interval
+#
 # [*agent_interval*]
 #  Configures agent fetching interval
 #
@@ -87,6 +90,7 @@ class telegraf (
   # [agent]
   $agent_hostname             = $::telegraf::params::agent_hostname,
   $agent_interval             = $::telegraf::params::agent_interval,
+  $agent_flush_interval       = $::telegraf::params::agent_flush_interval,
 
   # [[plugins.cpu]]
   $cpu_percpu                 = $::telegraf::params::cpu_percpu,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,6 +34,7 @@ class telegraf::params {
   # [agent]
   $agent_hostname            = $::hostname
   $agent_interval            = '10s'
+  $agent_flush_interval      = '10s'
 
   # [[plugins.cpu]]
   $cpu_percpu                 = true

--- a/templates/telegraf.conf.erb
+++ b/templates/telegraf.conf.erb
@@ -34,13 +34,13 @@
 # Configuration for telegraf agent
 [agent]
   # Default data collection interval for all plugins
-  interval = "10s"
+  interval = "<%= @agent_interval %>"
   # Rounds collection interval to 'interval'
   # ie, if interval="10s" then always collect on :00, :10, :20, etc.
   round_interval = true
 
   # Default data flushing interval for all outputs
-  flush_interval = "10s"
+  flush_interval = "<%= @agent_flush_interval %>"
   # Jitter the flush interval by a random range
   # ie, a jitter of 5s and interval 10s means flush will happen every 10-15s
   flush_jitter = "5s"


### PR DESCRIPTION
There was an option for agent_interval, but the template file hard coded it at 10s anyway.  There was no corresponding option for flush interval.  